### PR TITLE
Add events to their own collection

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -16,45 +16,44 @@ export function isCurrentlyBetweenTwoTimes(startTime, endTime) {
   return currentTime >= startTime && currentTime <= endTime;
 }
 
-export function isHappeningNow(eventSchedule){
-  return isToday(eventSchedule.byDay) && isCurrentlyBetweenTwoTimes(eventSchedule.startTime, eventSchedule.endTime);
+export function isHappeningNow(eventSchedule) {
+  return (
+    isToday(eventSchedule.byDay) &&
+    isCurrentlyBetweenTwoTimes(eventSchedule.startTime, eventSchedule.endTime)
+  );
 }
 
-export function isToday(byDay){
+export function isToday(byDay) {
   const daysOfWeek = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
   const currentDayOfWeek = daysOfWeek[new Date().getDay()];
   return byDay.includes(currentDayOfWeek);
 }
 
 export function hasActiveHappyHour(place, day) {
-  return place.events.some((event) => isActiveHappyHour(event,day));
+  return place.matchedEvents.events.some((event) =>
+    isActiveHappyHour(event, day)
+  );
 }
 
 export function isActiveHappyHour(event, day) {
-  if(event.keywords != "happyHour")
-    return false;
+  if (event.keywords != "happyHour") return false;
 
   const schedules = event.eventSchedule;
   return schedules.some((schedule) => {
-    return schedule.byDay.includes(convertDayName(day)) &&
-      isCurrentlyBetweenTwoTimes(
-        schedule.startTime,
-        schedule.endTime
-      )
+    return (
+      schedule.byDay.includes(convertDayName(day)) &&
+      isCurrentlyBetweenTwoTimes(schedule.startTime, schedule.endTime)
+    );
   });
 }
 
-export function formatTimeDisplay(schedule){
+export function formatTimeDisplay(schedule) {
   const startTime = formatHourDisplay(schedule.startTime);
   const endTime = formatHourDisplay(schedule.endTime);
-  if(schedule.startTime && schedule.endTime)
-    return `${startTime}-${endTime}`;
-  else if (schedule.startTime)
-    return `After ${startTime}`;
-  else if (schedule.endTime)
-    return `Before ${endTime}`;
-  else
-    return "All day";
+  if (schedule.startTime && schedule.endTime) return `${startTime}-${endTime}`;
+  else if (schedule.startTime) return `After ${startTime}`;
+  else if (schedule.endTime) return `Before ${endTime}`;
+  else return "All day";
 }
 
 export function formatHourDisplay(timeInt) {
@@ -75,4 +74,3 @@ export function formatHourDisplay(timeInt) {
     return `${convertedHour}${period}`;
   }
 }
-

--- a/pages/api/neighborhood/[neighborhood].js
+++ b/pages/api/neighborhood/[neighborhood].js
@@ -14,7 +14,7 @@ export default async function handler(req, res) {
     let { db } = await connectToDatabase();
     let places = await db
       // .find({ enabled: { $eq: true }, neighborhood: { $regex: neighborhood } })
-      .collection("eventPlaces")
+      .collection("places")
       .aggregate([
         {
           $match: {

--- a/pages/api/neighborhood/[neighborhood].js
+++ b/pages/api/neighborhood/[neighborhood].js
@@ -12,20 +12,31 @@ export default async function handler(req, res) {
 
   try {
     let { db } = await connectToDatabase();
-    let places = await db
-      // .find({ enabled: { $eq: true }, neighborhood: { $regex: neighborhood } })
+
+    // Retrieve places with events for the specified day of the week
+    let placesWithEvents = await db
       .collection("places")
       .aggregate([
         {
           $match: {
             enabled: true,
             neighborhood: neighborhood,
-            events: {
-              $elemMatch: {
-                keywords: "happyHour",
-                "eventSchedule.byDay": dayOfWeek,
-              },
-            },
+          },
+        },
+        {
+          $lookup: {
+            from: "events",
+            localField: "_id",
+            foreignField: "placeId",
+            as: "matchedEvents",
+          },
+        },
+        {
+          $unwind: "$matchedEvents",
+        },
+        {
+          $match: {
+            "matchedEvents.events.eventSchedule.byDay": dayOfWeek,
           },
         },
         {
@@ -34,35 +45,11 @@ export default async function handler(req, res) {
             alt_id: 1,
             name: 1,
             location: 1,
-            events: {
-              $filter: {
-                input: "$events",
-                as: "event",
-                cond: {
-                  $and: [
-                    { $eq: ["$$event.keywords", "happyHour"] },
-                    {
-                      $gt: [
-                        {
-                          $size: {
-                            $filter: {
-                              input: "$$event.eventSchedule",
-                              as: "schedule",
-                              cond: { $in: [dayOfWeek, "$$schedule.byDay"] },
-                            },
-                          },
-                        },
-                        0,
-                      ],
-                    },
-                  ],
-                },
-              },
-            },
             enabled: 1,
             featured: 1,
             neighborhood: 1,
             lastUpdated: 1,
+            matchedEvents: 1, // Include other fields if needed
           },
         },
         {
@@ -70,11 +57,13 @@ export default async function handler(req, res) {
         },
       ])
       .toArray();
+
     return res.json({
-      places: JSON.parse(JSON.stringify(places)),
+      places: JSON.parse(JSON.stringify(placesWithEvents)),
       success: true,
     });
   } catch (error) {
+    console.error("Error:", error);
     return res.json({
       places: new Error(error).message,
       success: false,

--- a/pages/api/neighborhood/index.js
+++ b/pages/api/neighborhood/index.js
@@ -29,7 +29,7 @@ async function getPlaces(req, res) {
   try {
     let { db } = await connectToDatabase();
     let places = await db
-      .collection("eventPlaces")
+      .collection("places")
       .find({ enabled: { $eq: true } })
       .toArray();
     return res.json({

--- a/pages/api/place/[name].js
+++ b/pages/api/place/[name].js
@@ -7,7 +7,7 @@ export default async function handler(req, res) {
   try {
     let { db } = await connectToDatabase();
     let place = await db
-      .collection("eventPlaces")
+      .collection("places")
       .findOne({ _id: new ObjectId(placeId) });
     return res.json({
       place: JSON.parse(JSON.stringify(place)),

--- a/pages/api/place/index.js
+++ b/pages/api/place/index.js
@@ -29,7 +29,7 @@ async function getPlaces(req, res) {
   try {
     let { db } = await connectToDatabase();
     let places = await db
-      .collection("eventPlaces")
+      .collection("places")
       .find({ enabled: { $eq: true } }, { skipSessions: true })
       .toArray();
     return res.json({
@@ -50,7 +50,7 @@ async function addPlace(req, res) {
 
     const parsedBody = JSON.parse(req.body);
 
-    await db.collection("eventPlaces").insertOne(parsedBody);
+    await db.collection("places").insertOne(parsedBody);
 
     return res.json({
       message: "Added place successfully",

--- a/pages/api/places/index.js
+++ b/pages/api/places/index.js
@@ -29,7 +29,7 @@ async function getPlaces(req, res) {
   try {
     let { db } = await connectToDatabase();
     let places = await db
-      .collection("eventPlaces")
+      .collection("places")
       .find({ enabled: { $eq: true } }, { skipSessions: true })
       .toArray();
     return res.json({
@@ -50,7 +50,7 @@ async function addPlace(req, res) {
 
     const parsedBody = JSON.parse(req.body);
 
-    await db.collection("eventPlaces").insertOne(parsedBody);
+    await db.collection("places").insertOne(parsedBody);
 
     return res.json({
       message: "Added place successfully",

--- a/pages/api/search/[search].js
+++ b/pages/api/search/[search].js
@@ -5,12 +5,44 @@ export default async function handler(req, res) {
 
   try {
     let { db } = await connectToDatabase();
-    let places = await db
+    let placesWithEvents = await db
       .collection("places")
-      .find({ name: { $regex: search, $options: "i" }, enabled: { $eq: true } })
+      .aggregate([
+        {
+          $match: {
+            name: { $regex: search, $options: "i" },
+            enabled: true,
+          },
+        },
+        {
+          $lookup: {
+            from: "events",
+            localField: "_id",
+            foreignField: "placeId",
+            as: "matchedEvents",
+          },
+        },
+        {
+          $unwind: "$matchedEvents",
+        },
+        {
+          $project: {
+            _id: 1,
+            alt_id: 1,
+            name: 1,
+            location: 1,
+            enabled: 1,
+            featured: 1,
+            neighborhood: 1,
+            lastUpdated: 1,
+            matchedEvents: 1, // Include other fields if needed
+          },
+        },
+      ])
       .toArray();
+
     return res.json({
-      places: JSON.parse(JSON.stringify(places)),
+      places: JSON.parse(JSON.stringify(placesWithEvents)),
       success: true,
     });
   } catch (error) {

--- a/pages/api/search/[search].js
+++ b/pages/api/search/[search].js
@@ -6,7 +6,7 @@ export default async function handler(req, res) {
   try {
     let { db } = await connectToDatabase();
     let places = await db
-      .collection("eventPlaces")
+      .collection("places")
       .find({ name: { $regex: search, $options: "i" }, enabled: { $eq: true } })
       .toArray();
     return res.json({

--- a/pages/api/search/index.js
+++ b/pages/api/search/index.js
@@ -29,7 +29,7 @@ async function getPlaces(req, res) {
   try {
     let { db } = await connectToDatabase();
     let places = await db
-      .collection("eventPlaces")
+      .collection("places")
       .find({ enabled: { $eq: true } })
       .toArray();
     return res.json({

--- a/pages/index.js
+++ b/pages/index.js
@@ -76,9 +76,7 @@ function Home() {
     const currentTime = new Date();
     const currentDay = currentTime.getDay();
 
-    const todayPlace = places.filter(
-      (place) => hasActiveHappyHour(place, day)
-    );
+    const todayPlace = places.filter((place) => hasActiveHappyHour(place, day));
 
     return todayPlace.length;
   }

--- a/pages/place.js
+++ b/pages/place.js
@@ -12,8 +12,6 @@ export default function SinglePlace() {
     ? router.query.id
     : router.asPath.split("=")[1];
 
-  console.log("router", router.asPath.split("=")[1]);
-
   const { data, error } = useSWR("/api/place/" + placeId, fetcher);
 
   if (error) return <div>Failed to load</div>;
@@ -24,7 +22,7 @@ export default function SinglePlace() {
       <Meta title={`${data.place.name} Daily Specials`} />
       <Header title='Everyday Specials' />
       <div className='flex flex-col items-center'>
-        <div className="md:w-1/2">
+        <div className='md:w-1/2'>
           <Place place={data.place} day='allDays' showDays={true} />
         </div>
       </div>

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -29,8 +29,6 @@ export default function SearchIndex() {
 
   const bars = places.slice(0, amountOfPlaces);
 
-  console.log(places);
-
   return (
     <div className='m-2'>
       <Meta title='Hello Chicago - Search' />
@@ -47,7 +45,12 @@ export default function SearchIndex() {
               </div>
             ) : (
               bars.map((bar) => (
-                <Place place={bar} day={"allDays"} showDays={true} key={bar._id} />
+                <Place
+                  place={bar}
+                  day={"allDays"}
+                  showDays={true}
+                  key={bar._id}
+                />
               ))
             )}
             {bars && bars.length >= 10 && bars.length !== places.length ? (

--- a/scripts/createEvents.js
+++ b/scripts/createEvents.js
@@ -22,21 +22,21 @@ async function aggregateAndImportEvents(
 
     await cursor.forEach(async (doc) => {
       if (doc.events.length > 0) {
-        if (!eventsMap.has(doc.name)) {
-          eventsMap.set(doc.name, {
+        if (!eventsMap.has(doc._id)) {
+          eventsMap.set(doc._id, {
             placeId: doc._id, // Store the place id
             events: [],
           });
         }
-        eventsMap.get(doc.name).events.push(...doc.events);
+        eventsMap.get(doc._id).events.push(...doc.events);
         delete doc.events;
 
-        console.log(`Events from ${doc.name} aggregated.`);
+        console.log(`Events from ${doc._id} aggregated.`);
       }
     });
 
     // Insert aggregated events into the target collection
-    for (const [{ placeId, events }] of eventsMap) {
+    for (const [placeId, { events }] of eventsMap) {
       await targetCollection.insertOne({
         placeId: placeId,
         events: events,
@@ -51,6 +51,7 @@ async function aggregateAndImportEvents(
         { events: { $exists: true } },
         { $unset: { events: "" } }
       );
+
       console.log(
         `Events along with names and place IDs imported to ${targetCollectionName} collection.`
       );

--- a/scripts/createEvents.js
+++ b/scripts/createEvents.js
@@ -1,0 +1,76 @@
+const MongoClient = require("mongodb").MongoClient;
+
+async function aggregateAndImportEvents(
+  uri,
+  dbName,
+  sourceCollectionName,
+  targetCollectionName
+) {
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const database = client.db(dbName);
+    const sourceCollection = database.collection(sourceCollectionName);
+    const targetCollection = database.collection(targetCollectionName);
+
+    const cursor = await sourceCollection.find({
+      events: { $exists: true, $ne: [] },
+    });
+
+    const eventsMap = new Map(); // Map to aggregate events for each name
+
+    await cursor.forEach(async (doc) => {
+      if (doc.events.length > 0) {
+        if (!eventsMap.has(doc.name)) {
+          eventsMap.set(doc.name, []);
+        }
+        eventsMap.get(doc.name).push(...doc.events);
+        delete doc.events;
+
+        console.log(`Events from ${doc.name} aggregated.`);
+      }
+    });
+
+    // Insert aggregated events into the target collection
+    for (const [name, events] of eventsMap) {
+      await targetCollection.insertOne({
+        name: name,
+        events: events,
+      });
+      console.log(
+        `Aggregated events for ${name} imported to ${targetCollectionName} collection.`
+      );
+    }
+
+    if (eventsMap.length === 0) {
+      console.log("No events found to import.");
+    } else {
+      await Promise.all(eventsMap);
+      await sourceCollection.updateMany(
+        { events: { $exists: true } },
+        { $unset: { events: "" } }
+      );
+      console.log(
+        `Events along with names removed from documents and imported to ${targetCollectionName} collection.`
+      );
+    }
+
+    await client.close();
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+// Usage example
+const uri = "mongodb://0.0.0.0:27017/";
+const dbName = "littletabs";
+const sourceCollectionName = "places";
+const targetCollectionName = "events";
+
+aggregateAndImportEvents(
+  uri,
+  dbName,
+  sourceCollectionName,
+  targetCollectionName
+);


### PR DESCRIPTION
I tried my hand at more mongo queries since that's not my strong suite. 

@smacmullan let me know what you think slash if I should do this differently. Example of an events document...I also don't really need the name anymore since the conversion script I wrote uses the id/placeId as the vocie of reason..

```{
  "_id": {
    "$oid": "65f47063d387a699edf11e25"
  },
  "placeId": {
    "$oid": "62bf13d3610a170199ad468f"
  },
  "name": "Outside Voices",
  "events": [
    {
      "keywords": "happyHour",
      "lastUpdated": "2022-12-30T15:14:28.968Z",
      "eventSchedule": [
        {
          "byDay": [
            "FR"
          ],
          "startTime": "null",
          "endTime": "null"
        }
      ],
      "menu": [
        {
          "name": "Frozen Cocktails",
          "category": "Drink",
          "price": 8
        },
        {
          "name": "Lambrusco",
          "category": "Drink",
          "price": 6
        },
        {
          "name": "Glass Pours",
          "category": "Drink",
          "price": 8
        },
        {
          "name": " 3-6p"
        }
      ]
    }
  ]
}```